### PR TITLE
chore: Add type to dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "fix"
+      prefix: "chore"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "fix"


### PR DESCRIPTION
Currently, the dependabot configuration for this repository is creating PRs that don't pass the rules of this very GitHub Action. However, you can configure the dependabot commit-message to use a prefix. I've used the prefix for `fix` in this config file because that's what I saw the past dependabot PRs were edited to. I do think these should usually either go under `refactor` or `chore`, but I just wanted to match whatever else I saw in the repo.