### PR TITLE
feat: Allow custom tags 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,5 +7,8 @@ module.exports = {
   env: {
     node: true,
     jest: true
+  },
+  rules: {
+    "no-console": "off"
   }
 };

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,5 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
+          valid-tags: Feature,Fix,Tech
       - run: yarn lint && yarn test

--- a/README.md
+++ b/README.md
@@ -41,4 +41,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+## Configuration
+
+No configuration is necessary by default.
+
+```yml
+# By default types specified in commitizen/conventional-commit-types is used.
+# See: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json
+# You can override the valid types
+types:
+  - feat
+  - fix
+  - docs
+  - foo
+  - bar
+```
+
 Note the usage of [`pull_request_target`](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) as the event trigger is necessary for a fork-based workflow so the API token is valid for status reporting.

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,16 @@
 name: semantic-pull-request
 author: Jan Amann <jan@amann.me>
 description: Ensure your PR title matches the Conventional Commits spec (https://www.conventionalcommits.org/).
+
+inputs:
+  valid-tags:
+    description: "Tags to check PR title for"
+    required: true
+
 runs:
   using: 'node12'
   main: 'index.js'
 branding:
   icon: 'shield'
   color: 'green'
+  

--- a/src/index.js
+++ b/src/index.js
@@ -29,10 +29,23 @@ module.exports = async function run() {
     // Pull requests that start with "[WIP] " are excluded from the check.
     const isWip = /^\[WIP\]\s/.test(pullRequest.title);
 
+    let types = [];
+
+    if (process.env.INPUT_TYPES != null) {
+      types = github.GitHub(process.env.VALID_TAGS).split(',');
+    }
+
+    if (!types || !types.length > 0) {
+      console.log('Checked types:');
+      console.log(types.join(', '));
+    } else {
+      console.log('No types');
+    }
+
     let validationError;
     if (!isWip) {
       try {
-        await validatePrTitle(pullRequest.title);
+        await validatePrTitle(pullRequest.title, types);
       } catch (error) {
         validationError = error;
       }

--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -2,7 +2,7 @@ const conventionalCommitsConfig = require('conventional-changelog-conventionalco
 const conventionalCommitTypes = require('conventional-commit-types');
 const parser = require('conventional-commits-parser').sync;
 
-module.exports = async function validatePrTitle(prTitle) {
+module.exports = async function validatePrTitle(prTitle, types) {
   const {parserOpts} = await conventionalCommitsConfig();
   const result = parser(prTitle, parserOpts);
 
@@ -13,7 +13,12 @@ module.exports = async function validatePrTitle(prTitle) {
     );
   }
 
-  const allowedTypes = Object.keys(conventionalCommitTypes.types);
+  let allowedTypes = types;
+
+  if (!allowedTypes || !allowedTypes.length > 0) {
+    allowedTypes = Object.keys(conventionalCommitTypes.types);
+  }
+
   if (!allowedTypes.includes(result.type)) {
     throw new Error(
       `Unknown release type "${result.type}" found in pull request title "${prTitle}".` +

--- a/src/validatePrTitle.test.js
+++ b/src/validatePrTitle.test.js
@@ -15,6 +15,16 @@ it('detects valid PR titles', async () => {
   }
 });
 
+it('detects valid PR titles with custom tags', async () => {
+  const inputs = ['fix: Fix bug', 'feat: Add feature', 'foo: Internal cleanup'];
+
+  for (let index = 0; index < inputs.length; index++) {
+    const input = inputs[index];
+    const types = ['fix', 'feat', 'foo'];
+    await validatePrTitle(input, types);
+  }
+});
+
 it('throws for PR titles without a type', async () => {
   await expect(validatePrTitle('Fix bug')).rejects.toThrow(
     /No release type found in pull request title "Fix bug"./
@@ -23,6 +33,12 @@ it('throws for PR titles without a type', async () => {
 
 it('throws for PR titles with an unknown type', async () => {
   await expect(validatePrTitle('foo: Bar')).rejects.toThrow(
+    /Unknown release type "foo" found in pull request title "foo: Bar"./
+  );
+});
+
+it('throws for PR titles with an unknown type with custom types', async () => {
+  await expect(validatePrTitle('foo: Bar', ['fix', 'feature'])).rejects.toThrow(
     /Unknown release type "foo" found in pull request title "foo: Bar"./
   );
 });


### PR DESCRIPTION
Closes #39 

With this PR I've duplicated what https://github.com/zeke/semantic-pull-requests to allow custoom types! Yay!

How can I test te action? I've added some tests to validatePrTitles test, but how can I be sure the actions work?