### PR TITLE
fix: Allow validation to pass when `subjectPatternError` is provided

### DIFF
--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -64,27 +64,29 @@ module.exports = async function validatePrTitle(
     );
   }
 
+  function throwSubjectPatternError(message) {
+    if (subjectPatternError) {
+      message = formatMessage(subjectPatternError, {
+        subject: result.subject,
+        title: prTitle
+      });
+    }
+
+    throw new Error(message);
+  }
+
   if (subjectPattern) {
     const match = result.subject.match(new RegExp(subjectPattern));
 
-    if (subjectPatternError) {
-      throw new Error(
-        formatMessage(subjectPatternError, {
-          subject: result.subject,
-          title: prTitle
-        })
-      );
-    }
-
     if (!match) {
-      throw new Error(
+      throwSubjectPatternError(
         `The subject "${result.subject}" found in pull request title "${prTitle}" doesn't match the configured pattern "${subjectPattern}".`
       );
     }
 
     const matchedPart = match[0];
     if (matchedPart.length !== result.subject.length) {
-      throw new Error(
+      throwSubjectPatternError(
         `The subject "${result.subject}" found in pull request title "${prTitle}" isn't an exact match for the configured pattern "${subjectPattern}". Please provide a subject that matches the whole pattern exactly.`
       );
     }

--- a/src/validatePrTitle.test.js
+++ b/src/validatePrTitle.test.js
@@ -108,6 +108,14 @@ describe('description validation', () => {
     await validatePrTitle('fix: sK!"§4123');
   });
 
+  it('can pass the validation when `subjectPatternError` is configured', async () => {
+    await validatePrTitle('fix: foobar', {
+      subjectPattern: '^(?![A-Z]).+$',
+      subjectPatternError:
+        'The subject found in the pull request title cannot start with an uppercase character.'
+    });
+  });
+
   it('uses the `subjectPatternError` if available when the `subjectPattern` does not match', async () => {
     const customError =
       'The subject found in the pull request title cannot start with an uppercase character.';


### PR DESCRIPTION
<!--

Thank you very much for contributing to this project!

Please make sure to have a look at the [contributors guide](https://github.com/amannn/action-semantic-pull-request/blob/master/CONTRIBUTORS.md) so you can test your changes.

For any non-trivial changes, please include a link to a workflow where you tested the current state of this pull request (see contributors guide).

-->

Fixes #78
