### PR TITLE
feat: Add ability to use multiple scopes

### DIFF
--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -28,6 +28,10 @@ module.exports = async function validatePrTitle(
       .join('\n')}`;
   }
 
+  function isUnknownScope(s) {
+    return scopes && !scopes.includes(s);
+  }
+
   if (!result.type) {
     throw new Error(
       `No release type found in pull request title "${prTitle}". Add a prefix to indicate what kind of release this pull request corresponds to (see https://www.conventionalcommits.org/).\n\n${printAvailableTypes()}`
@@ -54,11 +58,13 @@ module.exports = async function validatePrTitle(
     );
   }
 
-  if (scopes && result.scope && !scopes.includes(result.scope)) {
+  const givenScopes = result.scope ? result.scope.split(',') : undefined;
+  const unknownScopes = givenScopes ? givenScopes.filter(isUnknownScope) : [];
+  if (scopes && unknownScopes.length > 0) {
     throw new Error(
-      `Unknown scope "${
-        result.scope
-      }" found in pull request title "${prTitle}". Use one of the available scopes: ${scopes.join(
+      `Unknown scope(s) "${unknownScopes.join(
+        ','
+      )}" found in pull request title "${prTitle}". Use one of the available scopes: ${scopes.join(
         ', '
       )}.`
     );

--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -58,11 +58,15 @@ module.exports = async function validatePrTitle(
     );
   }
 
-  const givenScopes = result.scope ? result.scope.split(',') : undefined;
+  const givenScopes = result.scope
+    ? result.scope.split(',').map((scope) => scope.trim())
+    : undefined;
   const unknownScopes = givenScopes ? givenScopes.filter(isUnknownScope) : [];
   if (scopes && unknownScopes.length > 0) {
     throw new Error(
-      `Unknown scope(s) "${unknownScopes.join(
+      `Unknown ${
+        unknownScopes.length > 1 ? 'scopes' : 'scope'
+      } "${unknownScopes.join(
         ','
       )}" found in pull request title "${prTitle}". Use one of the available scopes: ${scopes.join(
         ', '

--- a/src/validatePrTitle.test.js
+++ b/src/validatePrTitle.test.js
@@ -55,11 +55,25 @@ describe('defined scopes', () => {
     await validatePrTitle('fix(core): Bar', {scopes: ['core']});
   });
 
+  it('allows multiple matching scopes', async () => {
+    await validatePrTitle('fix(core,e2e): Bar', {
+      scopes: ['core', 'e2e', 'web']
+    });
+  });
+
+  it('throws when an unknown scope is detected within multiple scopes', async () => {
+    await expect(
+      validatePrTitle('fix(core,e2e,foo,bar): Bar', {scopes: ['foo', 'core']})
+    ).rejects.toThrow(
+      'Unknown scope(s) "e2e,bar" found in pull request title "fix(core,e2e,foo,bar): Bar". Use one of the available scopes: foo, core.'
+    );
+  });
+
   it('throws when an unknown scope is detected', async () => {
     await expect(
       validatePrTitle('fix(core): Bar', {scopes: ['foo']})
     ).rejects.toThrow(
-      'Unknown scope "core" found in pull request title "fix(core): Bar". Use one of the available scopes: foo.'
+      'Unknown scope(s) "core" found in pull request title "fix(core): Bar". Use one of the available scopes: foo.'
     );
   });
 

--- a/src/validatePrTitle.test.js
+++ b/src/validatePrTitle.test.js
@@ -65,7 +65,7 @@ describe('defined scopes', () => {
     await expect(
       validatePrTitle('fix(core,e2e,foo,bar): Bar', {scopes: ['foo', 'core']})
     ).rejects.toThrow(
-      'Unknown scope(s) "e2e,bar" found in pull request title "fix(core,e2e,foo,bar): Bar". Use one of the available scopes: foo, core.'
+      'Unknown scopes "e2e,bar" found in pull request title "fix(core,e2e,foo,bar): Bar". Use one of the available scopes: foo, core.'
     );
   });
 
@@ -73,7 +73,7 @@ describe('defined scopes', () => {
     await expect(
       validatePrTitle('fix(core): Bar', {scopes: ['foo']})
     ).rejects.toThrow(
-      'Unknown scope(s) "core" found in pull request title "fix(core): Bar". Use one of the available scopes: foo.'
+      'Unknown scope "core" found in pull request title "fix(core): Bar". Use one of the available scopes: foo.'
     );
   });
 


### PR DESCRIPTION
<!--

Thank you very much for contributing to this project!

Please make sure to have a look at the [contributors guide](https://github.com/amannn/action-semantic-pull-request/blob/master/CONTRIBUTORS.md) so you can test your changes.

For any non-trivial changes, please include a link to a workflow where you tested the current state of this pull request (see contributors guide).

-->

This PR adds the oft-requested ability to use multiple scopes, and includes tests. For example:

feat(foo,bar): Add cool new feature