### PR TITLE
docs: Get rid of hardcoded version number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      # Please look up the latest version from https://github.com/amannn/action-semantic-pull-request/releases
+      # Please look up the latest version from
+      # https://github.com/amannn/action-semantic-pull-request/releases
       - uses: amannn/action-semantic-pull-request@vX.X.X
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v3.1.0
+      # Please look up the latest version from https://github.com/amannn/action-semantic-pull-request/releases
+      - uses: amannn/action-semantic-pull-request@vX.X.X
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
Resolves #92

<!--

Thank you very much for contributing to this project!

Please make sure to have a look at the [contributors guide](https://github.com/amannn/action-semantic-pull-request/blob/master/CONTRIBUTORS.md) so you can test your changes.

For any non-trivial changes, please include a link to a workflow where you tested the current state of this pull request (see contributors guide).

-->

Downside is that the user has to look up the version number and is not able to copy-paste, but that might be the safer choice than accidentally reference `master`.