### PR TITLE
fix: Make link in error clickable in GH Actions

### DIFF
--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -34,7 +34,7 @@ module.exports = async function validatePrTitle(
 
   if (!result.type) {
     throw new Error(
-      `No release type found in pull request title "${prTitle}". Add a prefix to indicate what kind of release this pull request corresponds to. For reference, see https://www.conventionalcommits.org/.\n\n${printAvailableTypes()}`
+      `No release type found in pull request title "${prTitle}". Add a prefix to indicate what kind of release this pull request corresponds to. For reference, see https://www.conventionalcommits.org/\n\n${printAvailableTypes()}`
     );
   }
 

--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -34,7 +34,7 @@ module.exports = async function validatePrTitle(
 
   if (!result.type) {
     throw new Error(
-      `No release type found in pull request title "${prTitle}". Add a prefix to indicate what kind of release this pull request corresponds to (see https://www.conventionalcommits.org/).\n\n${printAvailableTypes()}`
+      `No release type found in pull request title "${prTitle}". Add a prefix to indicate what kind of release this pull request corresponds to. For reference, see https://www.conventionalcommits.org/.\n\n${printAvailableTypes()}`
     );
   }
 


### PR DESCRIPTION
<!--

Thank you very much for contributing to this project!

Please make sure to have a look at the [contributors guide](https://github.com/amannn/action-semantic-pull-request/blob/master/CONTRIBUTORS.md) so you can test your changes.

For any non-trivial changes, please include a link to a workflow where you tested the current state of this pull request (see contributors guide).

-->

For PRs that fail due to the error "No release type found in pull request title", the resulting GH Actions log message link to [https://www.conventionalcommits.org/](https://www.conventionalcommits.org/) erroneously includes the closing parenthesis that results in a Page Not Found error when the link is clicked. For example, see [this job in the public rust-bio repo](https://github.com/rust-bio/rust-bio/pull/442/checks?check_run_id=3049032776).

This PR adjusts the error message text to remove the parentheses and thereby make the link point to the correct location. See [here ](https://github.com/dcroote/test-link-action/pull/1/checks?check_run_id=3052727152) for the job output of a mock PR in a mock repo that uses my forked workflow with the change.