### PR TITLE
fix: Single commit validation does not factor in merge commits [#108]

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,13 +58,16 @@ module.exports = async function run() {
             per_page: 2
           });
 
-          // GitHub does not count merge commits when deciding whether to use 
+          // GitHub does not count merge commits when deciding whether to use
           // the PR title or a commit message for the squash commit message.
-          const nonMergeCommits = commits.filter((commit) => !commit.message.startsWith("Merge branch"));
+          const nonMergeCommits = commits.filter(
+            (commit) => !commit.message.startsWith('Merge branch')
+          );
 
-          // If there is only one (non merge) commit present, GitHub will use that commit rather
-          // than the PR title for the title of a squash commit. To make sure a semantic title is used
-          // for the squash commit, we need to validate the commit title.
+          // If there is only one (non merge) commit present, GitHub will use
+          // that commit rather than the PR title for the title of a squash
+          // commit. To make sure a semantic title is used for the squash
+          // commit, we need to validate the commit title.
           if (nonMergeCommits.length === 1) {
             try {
               await validatePrTitle(commits[0].commit.message, {


### PR DESCRIPTION
Closes #108

With a recent change, GitHub no longer factors in merge commits added by the "update branch" button into whether to use the PR title. If a dev submits a PR with a single commit, then presses the "update branch" button, action-semantic-pull-request will allow the branch to be merged, however GitHub will still use the commit title rather than the PR title.