### PR TITLE
fix: Single commit validation does not factor in merge commits [#108]

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,9 +58,19 @@ module.exports = async function run() {
             per_page: 2
           });
 
-          if (commits.length === 1) {
+          // GitHub does not count merge commits when deciding whether to use
+          // the PR title or a commit message for the squash commit message.
+          const nonMergeCommits = commits.filter(
+            (commit) => !commit.commit.message.startsWith('Merge branch')
+          );
+
+          // If there is only one (non merge) commit present, GitHub will use
+          // that commit rather than the PR title for the title of a squash
+          // commit. To make sure a semantic title is used for the squash
+          // commit, we need to validate the commit title.
+          if (nonMergeCommits.length === 1) {
             try {
-              await validatePrTitle(commits[0].commit.message, {
+              await validatePrTitle(nonMergeCommits[0].commit.message, {
                 types,
                 scopes,
                 requireScope,


### PR DESCRIPTION
See https://github.com/julianpoy/action-semantic-pull-request/pull/2 for validation that this works.

Continuation of #127 

The problem with the original PR was that GitHub API returns a list of `commits` each with a property `commit` inside. When mapping over `commits => commit`, I forgot to add an additional chain for `commits => commit.commit`.

I also noticed that validatePrTitle should check the nonMergeCommit that we found in the case that there is, in fact, only one commit, rather than any one of the commits in case the first commit returned is a merge commit (for some strange reason).

Lastly, I noticed that the test workflows included in this repository (the one titled `current branch`) don't use any of the additional options that this repo has to offer, such as the `validateSingleCommit` option. I would recommend that the `current branch` workflow test for this repository either include these options, or that there be multiple workflows defined - one for each option.