### PR TITLE
docs: add job name to workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ on:
 
 jobs:
   main:
+    name: Validate PR title
     runs-on: ubuntu-latest
     steps:
       # Please look up the latest version from


### PR DESCRIPTION
Without the "job" having a name, it doesn't seem to be possible to add this workflow as a required check in GH branch protection.

Add this to the example in the README