### PR TITLE
feat: add support for Github Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ The action works without configuration, however you can provide options for cust
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
           validateSingleCommit: true
+          # If you use Github Enterprise, you can set this to the URL of your server
+          githubBaseUrl: https://github.myorg.com/api/v3
 ```
 
 ## Event triggers

--- a/action.yml
+++ b/action.yml
@@ -29,3 +29,6 @@ inputs:
   validateSingleCommit:
     description: "When using \"Squash and merge\" on a PR with only one commit, GitHub will suggest using that commit message instead of the PR title for the merge commit, and it's easy to commit this by mistake. Enable this option to also validate the commit message for one commit PRs." 
     required: false
+  githubBaseUrl:
+    description: "If you use Github Enterprise, you can set this to the URL of your server (e.g. https://github.myorg.com/api/v3)"
+    required: false

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ const validatePrTitle = require('./validatePrTitle');
 
 module.exports = async function run() {
   try {
-    const client = github.getOctokit(process.env.GITHUB_TOKEN);
     const {
       types,
       scopes,
@@ -13,8 +12,13 @@ module.exports = async function run() {
       wip,
       subjectPattern,
       subjectPatternError,
-      validateSingleCommit
+      validateSingleCommit,
+      githubBaseUrl
     } = parseConfig();
+
+    const client = github.getOctokit(process.env.GITHUB_TOKEN, {
+      baseUrl: githubBaseUrl
+    });
 
     const contextPullRequest = github.context.payload.pull_request;
     if (!contextPullRequest) {

--- a/src/parseConfig.js
+++ b/src/parseConfig.js
@@ -40,6 +40,11 @@ module.exports = function parseConfig() {
     );
   }
 
+  let githubBaseUrl;
+  if (process.env.INPUT_GITHUBBASEURL) {
+    githubBaseUrl = ConfigParser.parseString(process.env.INPUT_GITHUBBASEURL);
+  }
+
   return {
     types,
     scopes,
@@ -47,6 +52,7 @@ module.exports = function parseConfig() {
     wip,
     subjectPattern,
     subjectPatternError,
-    validateSingleCommit
+    validateSingleCommit,
+    githubBaseUrl
   };
 };


### PR DESCRIPTION
Workflow runs can be found here: https://github.com/feliperoveran/action-semantic-pull-request/actions

Works like a charm on GHES by providing:
```
with:
  githubServerUrl: https://github.myorg.com/api/v3
```