### PR TITLE
ci: add actions-tagger

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,11 @@
+name: 'Keep the versions up-to-date'
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  actions-tagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@v2


### PR DESCRIPTION
Resolves #151.

Since this repository uses `semantic-release` with `GITHUB_TOKEN`, it requires editing the release after it's published to trigger this workflow.

<!--

Thank you very much for contributing to this project!

Please make sure to have a look at the [contributors guide](https://github.com/amannn/action-semantic-pull-request/blob/master/CONTRIBUTORS.md) so you can test your changes.

For any non-trivial changes, please include a link to a workflow where you tested the current state of this pull request (see contributors guide).

-->
