### PR TITLE
feat(validateSingleCommit)!: check if the PR title matches the commit title

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ module.exports = async function run() {
               nonMergeCommits[0].commit.message.split('\n')[0];
             if (commitTitle !== pullRequest.title) {
               throw new Error(
-                `The pull request has only one (non-merge) commit and in this case Github will use it as the default commit message when merging. The pull request title doesn't match the commit though ("${pullRequest.title}" vs. "${commitTitle}"). Please update the pull request title accordingly to avoid surprises.
+                `The pull request has only one (non-merge) commit and in this case Github will use it as the default commit message when merging. The pull request title doesn't match the commit though ("${pullRequest.title}" vs. "${commitTitle}"). Please update the pull request title accordingly to avoid surprises.`
               );
             }
           }

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ module.exports = async function run() {
               nonMergeCommits[0].commit.message.split('\n')[0];
             if (commitTitle !== pullRequest.title) {
               throw new Error(
-                `The commit title "${commitTitle}" doesn't match the pull request title "${pullRequest.title}".`
+                `The pull request has only one (non-merge) commit and in this case Github will use it as the default commit message when merging. The pull request title doesn't match the commit though ("${pullRequest.title}" vs. "${commitTitle}"). Please update the pull request title accordingly to avoid surprises.
               );
             }
           }

--- a/src/index.js
+++ b/src/index.js
@@ -97,6 +97,11 @@ module.exports = async function run() {
                 `Pull request has only one commit and it's not semantic; this may lead to a non-semantic commit in the base branch (see https://github.community/t/how-to-change-the-default-squash-merge-commit-message/1155). Amend the commit message to match the pull request title, or add another commit.`
               );
             }
+
+            const commitTitle = nonMergeCommits[0].commit.message.split('\n')[0];
+            if (commitTitle !== pullRequest.title) {
+              throw new Error(`The commit title "${commitTitle}" doesn't match the pull request title "${pullRequest.title}".`);
+            }
           }
         }
       } catch (error) {

--- a/src/index.js
+++ b/src/index.js
@@ -98,9 +98,12 @@ module.exports = async function run() {
               );
             }
 
-            const commitTitle = nonMergeCommits[0].commit.message.split('\n')[0];
+            const commitTitle =
+              nonMergeCommits[0].commit.message.split('\n')[0];
             if (commitTitle !== pullRequest.title) {
-              throw new Error(`The commit title "${commitTitle}" doesn't match the pull request title "${pullRequest.title}".`);
+              throw new Error(
+                `The commit title "${commitTitle}" doesn't match the pull request title "${pullRequest.title}".`
+              );
             }
           }
         }


### PR DESCRIPTION
When we have a single semantic commit, even if we edit the PR title, it doesn't affect the squashed commit message. I think people usually don't want this behavior.

![image](https://user-images.githubusercontent.com/31987104/152540571-96703225-7dfb-41a6-acbc-216f99bd5ac1.png)

With this PR, we can ensure the PR title matches the commit title.

- Not match: https://github.com/kenji-miyake/action-semantic-pull-request/pull/3
- Match: https://github.com/kenji-miyake/action-semantic-pull-request/pull/4

@amannn I believe this will break the current behavior, so could you tell me how do you feel about it? Should I implement another parameter for this?