### PR TITLE
feat: add ignoreLabels option to force ignore errors

### DIFF
--- a/.github/workflows/lint-pr-title-preview-ignoreLabels.yml
+++ b/.github/workflows/lint-pr-title-preview-ignoreLabels.yml
@@ -1,0 +1,25 @@
+name: 'Lint PR title preview (current branch, ignoreLabels enabled)'
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - run: yarn install
+      - run: yarn build
+      - uses: ./
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request

--- a/.github/workflows/lint-pr-title-preview-ignoreLabels.yml
+++ b/.github/workflows/lint-pr-title-preview-ignoreLabels.yml
@@ -5,6 +5,8 @@ on:
       - opened
       - edited
       - synchronize
+      - labeled
+      - unlabeled
 
 jobs:
   main:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The action works without configuration, however you can provide options for cust
           validateSingleCommitMatchesPrTitle: true
           # If you use GitHub Enterprise, you can set this to the URL of your server
           githubBaseUrl: https://github.myorg.com/api/v3
+          ignoreLabels: |
+            bot
 ```
 
 ## Event triggers

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The action works without configuration, however you can provide options for cust
           # Multiple labels can be separated by newlines.
           ignoreLabels: |
             bot
+            ignore-semantic-pull-request
 ```
 
 ## Event triggers

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The action works without configuration, however you can provide options for cust
           githubBaseUrl: https://github.myorg.com/api/v3
           # If the PR contains one of these labels, the validation is skipped.
           # Multiple labels can be separated by newlines.
+          # If you want to rerun the validation when the labels has changed,
+          # add "labeled" and "unlabeled" conditions to your CI workflow.
           ignoreLabels: |
             bot
             ignore-semantic-pull-request

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The action works without configuration, however you can provide options for cust
           validateSingleCommitMatchesPrTitle: true
           # If you use GitHub Enterprise, you can set this to the URL of your server
           githubBaseUrl: https://github.myorg.com/api/v3
+          # If the PR contains one of these labels, the validation is skipped.
+          # Multiple labels can be separated by newlines.
           ignoreLabels: |
             bot
 ```

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ The action works without configuration, however you can provide options for cust
           githubBaseUrl: https://github.myorg.com/api/v3
           # If the PR contains one of these labels, the validation is skipped.
           # Multiple labels can be separated by newlines.
-          # If you want to rerun the validation when the labels has changed,
-          # add "labeled" and "unlabeled" conditions to your CI workflow.
+          # If you want to rerun the validation when labels change, you might want
+          # to use the `labeled` and `unlabeled` event triggers in your workflow.
           ignoreLabels: |
             bot
             ignore-semantic-pull-request

--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ inputs:
     description: "If you use Github Enterprise, you can set this to the URL of your server (e.g. https://github.myorg.com/api/v3)"
     required: false
   ignoreLabels:
-    description: "If the PR contains one of these labels, the validation is skipped. Multiple labels can be separated by newlines. If you want to rerun the validation when the labels has changed, add \"labeled\" and \"unlabeled\" conditions to your CI workflow."
+    description: "If the PR contains one of these labels, the validation is skipped. Multiple labels can be separated by newlines. If you want to rerun the validation when labels change, you might want to use the `labeled` and `unlabeled` event triggers in your workflow."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ inputs:
     description: "If you use Github Enterprise, you can set this to the URL of your server (e.g. https://github.myorg.com/api/v3)"
     required: false
   ignoreLabels:
-    description: "If the PR contains one of these labels, the validation is skipped. Multiple labels can be separated by newlines."
+    description: "If the PR contains one of these labels, the validation is skipped. Multiple labels can be separated by newlines. If you want to rerun the validation when the labels has changed, add \"labeled\" and \"unlabeled\" conditions to your CI workflow."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ inputs:
     description: "If you use Github Enterprise, you can set this to the URL of your server (e.g. https://github.myorg.com/api/v3)"
     required: false
   ignoreLabels:
-    description: "If specified labels are added to a PR, you can ignore the validation result. It is useful for PRs created by bots."
+    description: "If the PR contains one of these labels, the validation is skipped. Multiple labels can be separated by newlines."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -35,3 +35,6 @@ inputs:
   githubBaseUrl:
     description: "If you use Github Enterprise, you can set this to the URL of your server (e.g. https://github.myorg.com/api/v3)"
     required: false
+  ignoreLabels:
+    description: "If specified labels are added to a PR, you can ignore the validation result. It is useful for PRs created by bots."
+    required: false

--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,7 @@ module.exports = async function run() {
     if (ignoreLabels && validationError) {
       const labelNames = pullRequest.labels.map((label) => label.name);
       for (const labelName of labelNames) {
-        if (ignoreLabels.includes(label_name)) {
+        if (ignoreLabels.includes(labelName)) {
           core.info(
             `Validation was skipped because the PR label "${labelName}" was found.`
           );

--- a/src/index.js
+++ b/src/index.js
@@ -119,12 +119,14 @@ module.exports = async function run() {
     // Ignore errors if specified labels are added.
     if (ignoreLabels && validationError) {
       const labelNames = pullRequest.labels.map((label) => label.name);
-      if (labelNames.some((label_name) => ignoreLabels.includes(label_name))) {
-        core.info(
-          `The validation error was ignored because one of the PR label [${labelNames}] was in [${ignoreLabels}].`
-        );
-        core.info(`The ignored error message is: ${validationError}`);
-        validationError = null;
+      for (const labelName of labelNames) {
+        if (ignoreLabels.includes(label_name)) {
+          core.info(
+            `Validation was skipped because the PR label "${labelName}" was found.`
+          );
+          validationError = null;
+          break;
+        }
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -118,10 +118,10 @@ module.exports = async function run() {
 
     // Ignore errors if specified labels are added.
     if (ignoreLabels && validationError) {
-      const label_names = pullRequest.labels.map((label) => label.name);
-      if (label_names.some((label_name) => ignoreLabels.includes(label_name))) {
+      const labelNames = pullRequest.labels.map((label) => label.name);
+      if (labelNames.some((label_name) => ignoreLabels.includes(label_name))) {
         core.info(
-          `The validation error was ignored because one of the PR label [${label_names}] was in [${ignoreLabels}].`
+          `The validation error was ignored because one of the PR label [${labelNames}] was in [${ignoreLabels}].`
         );
         core.info(`The ignored error message is: ${validationError}`);
         validationError = null;

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,19 @@ module.exports = async function run() {
       pull_number: contextPullRequest.number
     });
 
+    // Ignore errors if specified labels are added.
+    if (ignoreLabels) {
+      const labelNames = pullRequest.labels.map((label) => label.name);
+      for (const labelName of labelNames) {
+        if (ignoreLabels.includes(labelName)) {
+          core.info(
+            `Validation was skipped because the PR label "${labelName}" was found.`
+          );
+          return;
+        }
+      }
+    }
+
     // Pull requests that start with "[WIP] " are excluded from the check.
     const isWip = wip && /^\[WIP\]\s/.test(pullRequest.title);
 
@@ -113,20 +126,6 @@ module.exports = async function run() {
         }
       } catch (error) {
         validationError = error;
-      }
-    }
-
-    // Ignore errors if specified labels are added.
-    if (ignoreLabels && validationError) {
-      const labelNames = pullRequest.labels.map((label) => label.name);
-      for (const labelName of labelNames) {
-        if (ignoreLabels.includes(labelName)) {
-          core.info(
-            `Validation was skipped because the PR label "${labelName}" was found.`
-          );
-          validationError = null;
-          break;
-        }
       }
     }
 

--- a/src/parseConfig.js
+++ b/src/parseConfig.js
@@ -52,6 +52,11 @@ module.exports = function parseConfig() {
     githubBaseUrl = ConfigParser.parseString(process.env.INPUT_GITHUBBASEURL);
   }
 
+  let ignoreLabels;
+  if (process.env.INPUT_IGNORELABELS) {
+    ignoreLabels = ConfigParser.parseEnum(process.env.INPUT_IGNORELABELS);
+  }
+
   return {
     types,
     scopes,
@@ -61,6 +66,7 @@ module.exports = function parseConfig() {
     subjectPatternError,
     validateSingleCommit,
     validateSingleCommitMatchesPrTitle,
-    githubBaseUrl
+    githubBaseUrl,
+    ignoreLabels
   };
 };


### PR DESCRIPTION
It is useful to have a feature that can force ignore errors when a certain label is added.

It can be used to support the cases shown in https://github.com/amannn/action-semantic-pull-request/issues/159 with the `validateSingleCommitMatchesPrTitle` option enabled.

I've tested this in https://github.com/kenji-miyake/action-semantic-pull-request/pull/7.