### PR TITLE
feat: outputs the error messages

### DIFF
--- a/.github/workflows/lint-pr-title-preview-outputErrorMessage
+++ b/.github/workflows/lint-pr-title-preview-outputErrorMessage
@@ -20,9 +20,25 @@ jobs:
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Comment on PR 
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
         if: always()
-        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          message: ${{ steps.lint_pr_title.outputs.error_message }}
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+            
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+            
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:   
+          header: pr-title-lint-error
+          delete: true

--- a/.github/workflows/lint-pr-title-preview-outputErrorMessage
+++ b/.github/workflows/lint-pr-title-preview-outputErrorMessage
@@ -25,4 +25,4 @@ jobs:
         if: always()
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          message: ${{ steps.lint_pr_title.outputs.ERROR_MESSAGE }}
+          message: ${{ steps.lint_pr_title.outputs.error_message }}

--- a/.github/workflows/lint-pr-title-preview-outputErrorMessage
+++ b/.github/workflows/lint-pr-title-preview-outputErrorMessage
@@ -1,0 +1,28 @@
+name: "Lint PR title preview (current branch, outputErrorMessage)"
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - run: yarn install
+      - run: yarn build
+      - uses: ./
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Comment on PR 
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: ${{ steps.lint_pr_title.outputs.ERROR_MESSAGE }}

--- a/README.md
+++ b/README.md
@@ -115,16 +115,12 @@ There are two events that can be used as triggers for this action, each with dif
 
 ## Outputs
 
-- `error_message`: The error message created by this action case the validation fails
+In case the validation fails, this action will populate the `error_message` ouput.
 
-This actions outputs the error message raised in the validation, so you can use it in other steps or jobs.
+[An output can be used in other steps](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs), for example to comment the error message onto the pull request.
 
-- First, assign an ID to the action-semantic-pull-request step.
-- On the next step, add an "if: always()" to force it to run. This is necessary because otherwise the whole workflow would just stop when action-semantic-pull-request throws the error.
-- Get the output by using an expression pointing to the action-semantic-pull-request ID.
-- Do what you want with it.
-
-In the example below, we use the [sticky-pull-request-comment](https://github.com/marketplace/actions/sticky-pull-request-comment) action to create a comment in the PR with the error message outputed by this action.
+<details>
+<summary>Example</summary>
 
 ```yml
 name: "Lint PR"
@@ -142,23 +138,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v4
-        # Assign an ID to the step.
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Comment on PR
-        # Since this action throws an error that naturaly stops the workflow execution, 
-        # add an "if: always()" to force it to run.
-        # In this case, to comment on the PR.
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
         if: always()
-        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          # Get the output using an expression, pointing to the ID you assigned.
           message: ${{ steps.lint_pr_title.outputs.error_message }}
 ```
 
-You can read more about outputs in the [GitHub Documentation](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs).
+</details>
 
 ## Legacy configuration
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,24 @@ jobs:
         # condition you can continue the execution with the populated error message.
         if: always()
         with:
-          message: ${{ steps.lint_pr_title.outputs.error_message }}
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+            
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+            
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:   
+          header: pr-title-lint-error
+          delete: true
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ There are two events that can be used as triggers for this action, each with dif
 
 ## Outputs
 
-- `ERROR_MESSAGE`: The error message created by this action case the validation fails
+- `error_message`: The error message created by this action case the validation fails
 
 This actions outputs the error message raised in the validation, so you can use it in other steps or jobs.
 
@@ -155,7 +155,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           # Get the output using an expression, pointing to the ID you assigned.
-          message: ${{ steps.lint_pr_title.outputs.ERROR_MESSAGE }}
+          message: ${{ steps.lint_pr_title.outputs.error_message }}
 ```
 
 You can read more about outputs in the [GitHub Documentation](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs).

--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -134,7 +134,7 @@ module.exports = async function validatePrTitle(
   }
 
   function raiseError(message) {
-    core.setOutput('ERROR_MESSAGE', message);
+    core.setOutput('error_message', message);
 
     throw new Error(message);
   }

--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -134,7 +134,7 @@ module.exports = async function validatePrTitle(
   }
 
   function raiseError(message) {
-    core.setOutput('errorMessage', message);
+    core.setOutput('ERROR_MESSAGE', message);
 
     throw new Error(message);
   }

--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -6,7 +6,7 @@ const formatMessage = require('./formatMessage');
 
 const defaultTypes = Object.keys(conventionalCommitTypes.types);
 
-let errorMessage
+let errorMessage;
 
 module.exports = async function validatePrTitle(
   prTitle,
@@ -64,8 +64,10 @@ module.exports = async function validatePrTitle(
     throw new Error(errorMessage);
   }
 
-  if (!types.includes(result.type)) {    
-    errorMessage = `Unknown release type "${result.type}" found in pull request title "${prTitle}". \n\n${printAvailableTypes()}`;
+  if (!types.includes(result.type)) {
+    errorMessage = `Unknown release type "${
+      result.type
+    }" found in pull request title "${prTitle}". \n\n${printAvailableTypes()}`;
     throw new Error(errorMessage);
   }
 
@@ -83,7 +85,13 @@ module.exports = async function validatePrTitle(
 
   const unknownScopes = givenScopes ? givenScopes.filter(isUnknownScope) : [];
   if (scopes && unknownScopes.length > 0) {
-    errorMessage = `Unknown ${unknownScopes.length > 1 ? 'scopes' : 'scope'} "${unknownScopes.join(',')}" found in pull request title "${prTitle}". Use one of the available scopes: ${scopes.join(', ')}.`;
+    errorMessage = `Unknown ${
+      unknownScopes.length > 1 ? 'scopes' : 'scope'
+    } "${unknownScopes.join(
+      ','
+    )}" found in pull request title "${prTitle}". Use one of the available scopes: ${scopes.join(
+      ', '
+    )}.`;
     throw new Error(errorMessage);
   }
 
@@ -91,7 +99,9 @@ module.exports = async function validatePrTitle(
     ? givenScopes.filter(isDisallowedScope)
     : [];
   if (disallowScopes && disallowedScopes.length > 0) {
-    errorMessage = `Disallowed ${disallowedScopes.length === 1 ? 'scope was' : 'scopes were'} found: ${disallowScopes.join(', ')}`;
+    errorMessage = `Disallowed ${
+      disallowedScopes.length === 1 ? 'scope was' : 'scopes were'
+    } found: ${disallowScopes.join(', ')}`;
     throw new Error(errorMessage);
   }
 
@@ -125,5 +135,5 @@ module.exports = async function validatePrTitle(
     }
   }
 
-  core.setOutput("error_message", errorMessage)
+  core.setOutput('error_message', errorMessage);
 };

--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -6,8 +6,6 @@ const formatMessage = require('./formatMessage');
 
 const defaultTypes = Object.keys(conventionalCommitTypes.types);
 
-let errorMessage;
-
 module.exports = async function validatePrTitle(
   prTitle,
   {

--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -55,28 +55,29 @@ module.exports = async function validatePrTitle(
   }
 
   if (!result.type) {
-    errorMessage = `No release type found in pull request title "${prTitle}". Add a prefix to indicate what kind of release this pull request corresponds to. For reference, see https://www.conventionalcommits.org/\n\n${printAvailableTypes()}`;
-    throw new Error(errorMessage);
+    raiseError(
+      `No release type found in pull request title "${prTitle}". Add a prefix to indicate what kind of release this pull request corresponds to. For reference, see https://www.conventionalcommits.org/\n\n${printAvailableTypes()}`
+    );
   }
 
   if (!result.subject) {
-    errorMessage = `No subject found in pull request title "${prTitle}".`;
-    throw new Error(errorMessage);
+    raiseError(`No subject found in pull request title "${prTitle}".`);
   }
 
   if (!types.includes(result.type)) {
-    errorMessage = `Unknown release type "${
-      result.type
-    }" found in pull request title "${prTitle}". \n\n${printAvailableTypes()}`;
-    throw new Error(errorMessage);
+    raiseError(
+      `Unknown release type "${
+        result.type
+      }" found in pull request title "${prTitle}". \n\n${printAvailableTypes()}`
+    );
   }
 
   if (requireScope && !result.scope) {
-    errorMessage = `No scope found in pull request title "${prTitle}".`;
+    let message = `No scope found in pull request title "${prTitle}".`;
     if (scopes) {
-      errorMessage += ` Use one of the available scopes: ${scopes.join(', ')}.`;
+      message += ` Use one of the available scopes: ${scopes.join(', ')}.`;
     }
-    throw new Error(errorMessage);
+    raiseError(message);
   }
 
   const givenScopes = result.scope
@@ -85,24 +86,26 @@ module.exports = async function validatePrTitle(
 
   const unknownScopes = givenScopes ? givenScopes.filter(isUnknownScope) : [];
   if (scopes && unknownScopes.length > 0) {
-    errorMessage = `Unknown ${
-      unknownScopes.length > 1 ? 'scopes' : 'scope'
-    } "${unknownScopes.join(
-      ','
-    )}" found in pull request title "${prTitle}". Use one of the available scopes: ${scopes.join(
-      ', '
-    )}.`;
-    throw new Error(errorMessage);
+    raiseError(
+      `Unknown ${
+        unknownScopes.length > 1 ? 'scopes' : 'scope'
+      } "${unknownScopes.join(
+        ','
+      )}" found in pull request title "${prTitle}". Use one of the available scopes: ${scopes.join(
+        ', '
+      )}.`
+    );
   }
 
   const disallowedScopes = givenScopes
     ? givenScopes.filter(isDisallowedScope)
     : [];
   if (disallowScopes && disallowedScopes.length > 0) {
-    errorMessage = `Disallowed ${
-      disallowedScopes.length === 1 ? 'scope was' : 'scopes were'
-    } found: ${disallowScopes.join(', ')}`;
-    throw new Error(errorMessage);
+    raiseError(
+      `Disallowed ${
+        disallowedScopes.length === 1 ? 'scope was' : 'scopes were'
+      } found: ${disallowScopes.join(', ')}`
+    );
   }
 
   function throwSubjectPatternError(message) {
@@ -112,10 +115,7 @@ module.exports = async function validatePrTitle(
         title: prTitle
       });
     }
-
-    errorMessage = message;
-
-    throw new Error(message);
+    raiseError(message);
   }
 
   if (subjectPattern) {
@@ -136,4 +136,10 @@ module.exports = async function validatePrTitle(
   }
 
   core.setOutput('error_message', errorMessage);
+
+  function raiseError(message) {
+    core.setOutput('errorMessage', message);
+
+    throw new Error(message);
+  }
 };

--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -133,8 +133,6 @@ module.exports = async function validatePrTitle(
     }
   }
 
-  core.setOutput('error_message', errorMessage);
-
   function raiseError(message) {
     core.setOutput('errorMessage', message);
 


### PR DESCRIPTION
Resolves #178

Hello! I'm a new guy here. I took a look at the code and saw that with an easy fix I could "maybe" fix this problem that so many users want: outputs the error messages to other steps/jobs.

You already have @actions/core as a dependency. I just...

- add a reference to it in validadePrTitle.js
- create a let that will store the error message
- instead of just throwing the errors directly by formatting the error message directly in it, I save the message in this variable
- in the end, I use core.setOutputs to output the error message with the name: "error_message"

I must say: I'm new, not very experienced. I ran the tests and everything passed. But I didn't test in a real workflow. This behaviour is very useful for all users, if you could please take a look in it 🙏
