### PR TITLE
docs: update example GA workflow with PR comment

### DIFF
--- a/.github/workflows/lint-pr-title-preview-outputErrorMessage
+++ b/.github/workflows/lint-pr-title-preview-outputErrorMessage
@@ -23,7 +23,7 @@ jobs:
       - uses: marocchino/sticky-pull-request-comment@v2
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
-        if: always()
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
         with:
           header: pr-title-lint-error
           message: |

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ jobs:
       - uses: marocchino/sticky-pull-request-comment@v2
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
-        if: always()
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
         with:
           header: pr-title-lint-error
           message: |


### PR DESCRIPTION
Hey there! Thanks for the awesome action!

When trying out the example workflow for adding comments To PR from README, I noticed that sometimes I still see the comment in PR with empty error message, which disappears after reloading the page. This is of course due to Github's finicky synchronisation, but what really happens is that comment is created each time the workflow is run but then delete immediately if PR title validation passes. This PR improves this logic by adding additional condition to only create PR comment if Semantic PR action had actually failed.  