### PR TITLE
fix: upgrade GitHub Action to use Node16.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: semantic-pull-request
 author: Jan Amann <jan@amann.me>
 description: Ensure your PR title matches the Conventional Commits spec (https://www.conventionalcommits.org/).
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'shield'


### PR DESCRIPTION
See as well https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

<!--

Thank you very much for contributing to this project!

Please make sure to have a look at the [contributors guide](https://github.com/amannn/action-semantic-pull-request/blob/master/CONTRIBUTORS.md) so you can test your changes.

For any non-trivial changes, please include a link to a workflow where you tested the current state of this pull request (see contributors guide).

-->
