### PR TITLE
feat: add regex support to scope configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ feat(ui): Add `Button` component.
           scopes: |
             core
             ui
+            JIRA-\d+
             (?![A-Z])+
           # Configure that a scope must always be provided.
           requireScope: true

--- a/README.md
+++ b/README.md
@@ -62,16 +62,20 @@ feat(ui): Add `Button` component.
             fix
             feat
           # Configure which scopes are allowed (newline delimited).
+          # These are regex patterns auto-wrapped in `^ $`.
           scopes: |
             core
             ui
+            (?![A-Z])+
           # Configure that a scope must always be provided.
           requireScope: true
           # Configure which scopes (newline delimited) are disallowed in PR
           # titles. For instance by setting # the value below, `chore(release):
           # ...` and `ci(e2e,release): ...` will be rejected.
+          # These are regex patterns auto-wrapped in `^ $`.
           disallowScopes: |
             release
+            [A-Z]+
           # Configure additional validation for the subject based on a regex.
           # This example ensures the subject doesn't start with an uppercase character.
           subjectPattern: ^(?![A-Z]).+$

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ feat(ui): Add `Button` component.
             core
             ui
             JIRA-\d+
-            (?![A-Z])+
           # Configure that a scope must always be provided.
           requireScope: true
           # Configure which scopes (newline delimited) are disallowed in PR

--- a/action.yml
+++ b/action.yml
@@ -12,13 +12,13 @@ inputs:
     description: "Provide custom types (newline delimited) if you don't want the default ones from https://www.conventionalcommits.org."
     required: false
   scopes:
-    description: "Configure which scopes are allowed (newline delimited)."
+    description: "Configure which scopes are allowed (newline delimited). These are regex patterns auto-wrapped in `^ $`."
     required: false
   requireScope:
     description: "Configure that a scope must always be provided."
     required: false
   disallowScopes:
-    description: 'Configure which scopes are disallowed in PR titles (newline delimited).'
+    description: 'Configure which scopes are disallowed in PR titles (newline delimited). These are regex patterns auto-wrapped in ` ^$`.'
     required: false
   subjectPattern:
     description: "Configure additional validation for the subject based on a regex. E.g. '^(?![A-Z]).+$' ensures the subject doesn't start with an uppercase character."

--- a/src/ConfigParser.test.js
+++ b/src/ConfigParser.test.js
@@ -9,4 +9,9 @@ describe('parseEnum', () => {
       'four'
     ]);
   });
+  it('parses newline-delimited lists, including regex, trimming whitespace', () => {
+    expect(
+      ConfigParser.parseEnum('one   \ntwo   \n^[A-Z]+\\n$  \r\nfour')
+    ).toEqual(['one', 'two', '^[A-Z]+\\n$', 'four']);
+  });
 });

--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -45,11 +45,14 @@ module.exports = async function validatePrTitle(
   }
 
   function isUnknownScope(s) {
-    return scopes && !scopes.includes(s);
+    return scopes && !scopes.some((scope) => new RegExp(`^${scope}$`).test(s));
   }
 
   function isDisallowedScope(s) {
-    return disallowScopes && disallowScopes.includes(s);
+    return (
+      disallowScopes &&
+      disallowScopes.some((scope) => new RegExp(`^${scope}$`).test(s))
+    );
   }
 
   if (!result.type) {
@@ -102,7 +105,7 @@ module.exports = async function validatePrTitle(
     raiseError(
       `Disallowed ${
         disallowedScopes.length === 1 ? 'scope was' : 'scopes were'
-      } found: ${disallowScopes.join(', ')}`
+      } found: ${disallowedScopes.join(', ')}`
     );
   }
 

--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -76,7 +76,7 @@ module.exports = async function validatePrTitle(
   if (requireScope && !result.scope) {
     let message = `No scope found in pull request title "${prTitle}".`;
     if (scopes) {
-      message += ` Use one of the available scopes: ${scopes.join(', ')}.`;
+      message += ` Scope must match one of: ${scopes.join(', ')}.`;
     }
     raiseError(message);
   }
@@ -92,7 +92,7 @@ module.exports = async function validatePrTitle(
         unknownScopes.length > 1 ? 'scopes' : 'scope'
       } "${unknownScopes.join(
         ','
-      )}" found in pull request title "${prTitle}". Use one of the available scopes: ${scopes.join(
+      )}" found in pull request title "${prTitle}". Scope must match one of: ${scopes.join(
         ', '
       )}.`
     );

--- a/src/validatePrTitle.test.js
+++ b/src/validatePrTitle.test.js
@@ -75,7 +75,7 @@ describe('defined scopes', () => {
     await expect(
       validatePrTitle('fix(core,e2e,foo,bar): Bar', {scopes: ['foo', 'core']})
     ).rejects.toThrow(
-      'Unknown scopes "e2e,bar" found in pull request title "fix(core,e2e,foo,bar): Bar". Use one of the available scopes: foo, core.'
+      'Unknown scopes "e2e,bar" found in pull request title "fix(core,e2e,foo,bar): Bar". Scope must match one of: foo, core.'
     );
   });
 
@@ -85,7 +85,7 @@ describe('defined scopes', () => {
         scopes: ['foo', '[A-Z]+']
       })
     ).rejects.toThrow(
-      'Unknown scopes "e2e,bar" found in pull request title "fix(CORE,e2e,foo,bar): Bar". Use one of the available scopes: foo, [A-Z]+.'
+      'Unknown scopes "e2e,bar" found in pull request title "fix(CORE,e2e,foo,bar): Bar". Scope must match one of: foo, [A-Z]+.'
     );
   });
 
@@ -93,7 +93,7 @@ describe('defined scopes', () => {
     await expect(
       validatePrTitle('fix(core): Bar', {scopes: ['foo']})
     ).rejects.toThrow(
-      'Unknown scope "core" found in pull request title "fix(core): Bar". Use one of the available scopes: foo.'
+      'Unknown scope "core" found in pull request title "fix(core): Bar". Scope must match one of: foo.'
     );
   });
 
@@ -101,7 +101,7 @@ describe('defined scopes', () => {
     await expect(
       validatePrTitle('fix(score): Bar', {scopes: ['core']})
     ).rejects.toThrow(
-      'Unknown scope "score" found in pull request title "fix(score): Bar". Use one of the available scopes: core.'
+      'Unknown scope "score" found in pull request title "fix(score): Bar". Scope must match one of: core.'
     );
   });
 
@@ -109,7 +109,7 @@ describe('defined scopes', () => {
     await expect(
       validatePrTitle('fix(score): Bar', {scopes: ['^[A-Z]+$']})
     ).rejects.toThrow(
-      'Unknown scope "score" found in pull request title "fix(score): Bar". Use one of the available scopes: ^[A-Z]+$.'
+      'Unknown scope "score" found in pull request title "fix(score): Bar". Scope must match one of: ^[A-Z]+$.'
     );
   });
 
@@ -117,7 +117,7 @@ describe('defined scopes', () => {
     await expect(
       validatePrTitle('fix(core): Bar', {scopes: ['[A-Z]+']})
     ).rejects.toThrow(
-      'Unknown scope "core" found in pull request title "fix(core): Bar". Use one of the available scopes: [A-Z]+.'
+      'Unknown scope "core" found in pull request title "fix(core): Bar". Scope must match one of: [A-Z]+.'
     );
   });
 
@@ -137,7 +137,7 @@ describe('defined scopes', () => {
             requireScope: true
           })
         ).rejects.toThrow(
-          'No scope found in pull request title "fix: Bar". Use one of the available scopes: foo, bar.'
+          'No scope found in pull request title "fix: Bar". Scope must match one of: foo, bar.'
         );
       });
     });


### PR DESCRIPTION
## Reasoning

I would like to use this github action for PR validation in my project. It would be good as is, but we have adopted a convention where the `scope` includes a JIRA ticket ID, which in combination with github's auto-linking feature works wonders for readable changelogs. However, without regex support it's not possible to validate such scope.

I have also noticed that and issue for this already exists: Closes https://github.com/amannn/action-semantic-pull-request/issues/221

## Changes

I've changed existing fields for scope configuration (`scopes`, `disallowedScopes`) to be based around Regex, inspired by the solution for the `types` proposed in https://github.com/amannn/action-semantic-pull-request/issues/220

My reasoning behind it was, that adding separate `scopePattern` input would be a bit confusing, and would add configurational complexity with then having to ignore/throw on e.g. `scopes` being declared as well.

To ensure backwards compatibilty I made it so the regex is auto-wrapped in `^ $`. This can be problematic if someone doesn't want to match it from start to end, but can be worked around. I've also included tests to ensure double wrapping is not an issue.

I've included unit tests, tried to make it explicit with backwards compatibility.

Let me know if this makes sense :) 

## Demo PR

https://github.com/Kretolus/action-semantic-pull-request/pull/1