### PR TITLE
docs: Updated error link from a deprecated one to valid one.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ module.exports = async function run() {
               });
             } catch (error) {
               throw new Error(
-                `Pull request has only one commit and it's not semantic; this may lead to a non-semantic commit in the base branch (see https://github.community/t/how-to-change-the-default-squash-merge-commit-message/1155). Amend the commit message to match the pull request title, or add another commit.`
+                `Pull request has only one commit and it's not semantic; this may lead to a non-semantic commit in the base branch (see https://github.com/community/community/discussions/16271). Amend the commit message to match the pull request title, or add another commit.`
               );
             }
 


### PR DESCRIPTION
<!--

Thank you very much for contributing to this project!

Please make sure to have a look at the [contributors guide](https://github.com/amannn/action-semantic-pull-request/blob/master/CONTRIBUTORS.md), so you can test your changes.

For any non-trivial changes, please include a link to a workflow where you tested the current state of this pull request (see contributors guide).

-->

This link `https://github.community/t/how-to-change-the-default-squash-merge-commit-message/1155` that shows up in the error message is deprecated and is no longer available. It is migrated to `https://github.com/community/community/discussions/16271`.

This PR changes the error message link from `https://github.community/t/how-to-change-the-default-squash-merge-commit-message/1155` to `https://github.com/community/community/discussions/16271`.
