### PR TITLE
ci: fix permissions for sticky-pull-request-comment

### DIFF
--- a/.github/workflows/lint-pr-title-preview-outputErrorMessage.yml
+++ b/.github/workflows/lint-pr-title-preview-outputErrorMessage.yml
@@ -7,7 +7,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   main:

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   main:


### PR DESCRIPTION
**Description**: `sticky-pull-request-comment` requires the `pull-requests` permission set to `write` in order to post the message ([documentation](https://github.com/marocchino/sticky-pull-request-comment#error-resource-not-accessible-by-integration)).

**Workflow**: `Lint PR title preview (current branch, outputErrorMessage)]`

**PR on my fork**: [sheerlox/action-semantic-pull-request#1](https://github.com/sheerlox/action-semantic-pull-request/pull/1)

**Workflow runs on my fork**:
- [before fixing workflow file](https://github.com/sheerlox/action-semantic-pull-request/actions/runs/5370833232/jobs/9743196070?pr=1)
- [after fixing workflow file](https://github.com/sheerlox/action-semantic-pull-request/actions/runs/5370851692/jobs/9743228621?pr=1)
