### PR TITLE
chore: use github.api_url as default githubBaseUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ feat(ui): Add `Button` component
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the configured pattern. Please ensure that the subject
             doesn't start with an uppercase character.
-          # If you use GitHub Enterprise, you can set this to the URL of your server
+          # The GitHub base URL will be automatically set to the correct value from the GitHub context variable.
+          # If you want to override this, you can do so here (not recommended).
           githubBaseUrl: https://github.myorg.com/api/v3
           # If the PR contains one of these newline-delimited labels, the
           # validation is skipped. If you want to rerun the validation when

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,7 @@ inputs:
   githubBaseUrl:
     description: "If you use Github Enterprise, you can set this to the URL of your server (e.g. https://github.myorg.com/api/v3)"
     required: false
+    default: '${{ github.api_url }}'
   ignoreLabels:
     description: "If the PR contains one of these labels (newline delimited), the validation is skipped. If you want to rerun the validation when labels change, you might want to use the `labeled` and `unlabeled` event triggers in your workflow."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: "Related to `validateSingleCommit` you can opt-in to validate that the PR title matches a single commit to avoid confusion."
     required: false
   githubBaseUrl:
-    description: "If you use Github Enterprise, you can set this to the URL of your server (e.g. https://github.myorg.com/api/v3)"
+    description: "The GitHub base URL will be automatically set to the correct value from the GitHub context variable. If you want to override this, you can do so here (not recommended)."
     required: false
     default: '${{ github.api_url }}'
   ignoreLabels:


### PR DESCRIPTION
Currently the GitHub API URL has to be set manually.
This will change that you do not longer need to set the input on a GHE instance.

This change uses the [github context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context).