### PR TITLE
feat: Add outputs for `type`, `scope` and `subject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ There are two events that can be used as triggers for this action, each with dif
 
 ## Outputs
 
-- In any case, this action will populate the `type`, `scope` and `subject` ouputs.
-- In case the validation fails, this action will populate the `error_message` ouput.
+- The outputs `type`, `scope` and `subject` are populated, except for if the `wip` option is used.
+- The `error_message` output will be populated in case the validation fails.
 
 [An output can be used in other steps](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs), for example to comment the error message onto the pull request.
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ There are two events that can be used as triggers for this action, each with dif
 
 ## Outputs
 
-In case the validation fails, this action will populate the `error_message` ouput.
+- In any case, this action will populate the `type`, `scope` and `subject` ouputs.
+- In case the validation fails, this action will populate the `error_message` ouput.
 
 [An output can be used in other steps](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs), for example to comment the error message onto the pull request.
 
@@ -222,4 +223,3 @@ jobs:
 ```
 
 </details>
-

--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -29,6 +29,9 @@ module.exports = async function validatePrTitle(
     parserOpts.headerCorrespondence = headerPatternCorrespondence;
   }
   const result = parser(prTitle, parserOpts);
+  core.setOutput('type', result.type);
+  core.setOutput('scope', result.scope);
+  core.setOutput('subject', result.subject);
 
   function printAvailableTypes() {
     return `Available types:\n${types


### PR DESCRIPTION
Add in the GHA outputs type, scope and subject in order to use them after the action execution