### PR TITLE
chore(deps): Bump tar from 6.1.11 to 6.2.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5055,6 +5055,11 @@ minipass@^3.0.0, minipass@^3.1.1, minipass@^3.1.6:
   dependencies:
     yallist "^4.0.0"
 
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
 minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
@@ -6553,13 +6558,13 @@ supports-preserve-symlinks-flag@^1.0.0:
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 tar@^6.1.0, tar@^6.1.11, tar@^6.1.2:
-  version "6.1.11"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
-  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
+  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
-    minipass "^3.0.0"
+    minipass "^5.0.0"
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"


### PR DESCRIPTION
This PR is a request to fix the "Denial of service while parsing a tar file due to lack of folders count validation"

This Dependabot Moderate issue is also visible at https://github.com/advisories/GHSA-f5x3-32g6-xq36

these are displayed in :

    [CWE-400](https://cwe.mitre.org/data/definitions/400.htmll)

below is cited from Dependabot:
Bumps [tar](https://github.com/isaacs/node-tar) from 6.1.11 to 6.2.1.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/isaacs/node-tar/releases">tar's releases</a>.</em></p>
<blockquote>
<h2>v6.1.13</h2>
<h2><a href="https://github.com/npm/node-tar/compare/v6.1.12...v6.1.13">6.1.13</a> (2022-12-07)</h2>
<h3>Dependencies</h3>
<ul>
<li><a href="https://github.com/npm/node-tar/commit/cc4e0ddfe523a0bce383846a67442c637a65d486"><code>cc4e0dd</code></a> <a href="https://redirect.github.com/npm/node-tar/pull/343">#343</a> bump minipass from 3.3.6 to 4.0.0</li>
</ul>
<h2>v6.1.12</h2>
<h2><a href="https://github.com/npm/node-tar/compare/v6.1.11...v6.1.12">6.1.12</a> (2022-10-31)</h2>
<h3>Bug Fixes</h3>
<ul>
<li><a href="https://github.com/npm/node-tar/commit/57493ee66ece50d62114e02914282fc37be3a91a"><code>57493ee</code></a> <a href="https://redirect.github.com/npm/node-tar/pull/332">#332</a> ensuring close event is emited after stream has ended (<a href="https://github.com/webark"><code>@​webark</code></a>)</li>
<li><a href="https://github.com/npm/node-tar/commit/b003c64f624332e24e19b30dc011069bb6708680"><code>b003c64</code></a> <a href="https://redirect.github.com/npm/node-tar/pull/314">#314</a> replace deprecated String.prototype.substr() (<a href="https://redirect.github.com/isaacs/node-tar/issues/314">#314</a>) (<a href="https://github.com/CommanderRoot"><code>@​CommanderRoot</code></a>, <a href="https://github.com/lukekarrys"><code>@​lukekarrys</code></a>)</li>
</ul>
<h3>Documentation</h3>
<ul>
<li><a href="https://github.com/npm/node-tar/commit/f12992932f171ea248b27fad95e7d489a56d31ed"><code>f129929</code></a> <a href="https://redirect.github.com/npm/node-tar/pull/313">#313</a> remove dead link to benchmarks (<a href="https://redirect.github.com/isaacs/node-tar/issues/313">#313</a>) (<a href="https://github.com/yetzt"><code>@​yetzt</code></a>)</li>
<li><a href="https://github.com/npm/node-tar/commit/c1faa9f44001dfb0bc7638b2850eb6058bd56a4a"><code>c1faa9f</code></a> add examples/explanation of using tar.t (<a href="https://github.com/isaacs"><code>@​isaacs</code></a>)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/isaacs/node-tar/blob/main/CHANGELOG.md">tar's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<h2>7.0</h2>
<ul>
<li>Rewrite in TypeScript, provide ESM and CommonJS hybrid
interface</li>
<li>Add tree-shake friendly exports, like <code>import('tar/create')</code>
and <code>import('tar/read-entry')</code> to get individual functions or
classes.</li>
<li>Add <code>chmod</code> option that defaults to false, and deprecate
<code>noChmod</code>. That is, reverse the default option regarding
explicitly setting file system modes to match tar entry
settings.</li>
<li>Add <code>processUmask</code> option to avoid having to call
<code>process.umask()</code> when <code>chmod: true</code> (or <code>noChmod: false</code>) is
set.</li>
</ul>
<h2>6.2</h2>
<ul>
<li>Add support for brotli compression</li>
<li>Add <code>maxDepth</code> option to prevent extraction into excessively
deep folders.</li>
</ul>
<h2>6.1</h2>
<ul>
<li>remove dead link to benchmarks (<a href="https://redirect.github.com/isaacs/node-tar/issues/313">#313</a>) (<a href="https://github.com/yetzt"><code>@​yetzt</code></a>)</li>
<li>add examples/explanation of using tar.t (<a href="https://github.com/isaacs"><code>@​isaacs</code></a>)</li>
<li>ensure close event is emited after stream has ended (<a href="https://github.com/webark"><code>@​webark</code></a>)</li>
<li>replace deprecated String.prototype.substr() (<a href="https://github.com/CommanderRoot"><code>@​CommanderRoot</code></a>,
<a href="https://github.com/lukekarrys"><code>@​lukekarrys</code></a>)</li>
</ul>
<h2>6.0</h2>
<ul>
<li>Drop support for node 6 and 8</li>
<li>fix symlinks and hardlinks on windows being packed with
<code>\</code>-style path targets</li>
</ul>
<h2>5.0</h2>
<ul>
<li>Address unpack race conditions using path reservations</li>
<li>Change large-numbers errors from TypeError to Error</li>
<li>Add <code>TAR_*</code> error codes</li>
<li>Raise <code>TAR_BAD_ARCHIVE</code> warning/error when there are no valid
entries found in an archive</li>
<li>do not treat ignored entries as an invalid archive</li>
<li>drop support for node v4</li>
<li>unpack: conditionally use a file mapping to write files on
Windows</li>
<li>Set more portable 'mode' value in portable mode</li>
<li>Set <code>portable</code> gzip option in portable mode</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/isaacs/node-tar/commit/bef7b1e4ffab822681fea2a9b22187192ed14717"><code>bef7b1e</code></a> 6.2.1</li>
<li><a href="https://github.com/isaacs/node-tar/commit/fe8cd57da5686f8695415414bda49206a545f7f7"><code>fe8cd57</code></a> prevent extraction in excessively deep subfolders</li>
<li><a href="https://github.com/isaacs/node-tar/commit/fe7ebfdcede1f8a2e65db12e19ecc4b3a9934648"><code>fe7ebfd</code></a> remove security.md</li>
<li><a href="https://github.com/isaacs/node-tar/commit/5bc9d404e88c39870e0fbb55655a53de6fbf0a04"><code>5bc9d40</code></a> 6.2.0</li>
<li><a href="https://github.com/isaacs/node-tar/commit/fe1ef5ec87156ddadcec8b70cdec201f26665681"><code>fe1ef5e</code></a> changelog 6.2</li>
<li><a href="https://github.com/isaacs/node-tar/commit/e483220935d931cf6b09292aba62170e68f36205"><code>e483220</code></a> get rid of npm lint stuff</li>
<li><a href="https://github.com/isaacs/node-tar/commit/689928a0ba7d9b9014d88a5fa35261f9ae4ef2f3"><code>689928a</code></a> ci that works outside of npm org</li>
<li><a href="https://github.com/isaacs/node-tar/commit/db6f53928650a04b340ecdc01db2d49937e5d63c"><code>db6f539</code></a> file inference improvements for .tbr and .tgz</li>
<li><a href="https://github.com/isaacs/node-tar/commit/336fa8f27c44bec70d46a6482096af24c668ee16"><code>336fa8f</code></a> refactor: dry and other pr comments</li>
<li><a href="https://github.com/isaacs/node-tar/commit/eeba22238736ed0832488efb3c515ada98073424"><code>eeba222</code></a> chore: lint fixes</li>
<li>Additional commits viewable in <a href="https://github.com/isaacs/node-tar/compare/v6.1.11...v6.2.1">compare view</a></li>
</ul>
</details>
<br />
---
updated-dependencies:
- dependency-name: tar dependency-type: indirect ...

<!--

Thank you very much for contributing to this project!

Please make sure to have a look at the [contributors guide](https://github.com/amannn/action-semantic-pull-request/blob/master/CONTRIBUTORS.md) so you can test your changes.

For any non-trivial changes, please include a link to a workflow where you've tested the current state of this pull request (see contributors guide).

-->
