### PR TITLE
docs: More restrictive permissions

### DIFF
--- a/.github/workflows/lint-pr-title-preview-ignoreLabels.yml
+++ b/.github/workflows/lint-pr-title-preview-ignoreLabels.yml
@@ -8,12 +8,11 @@ on:
       - labeled
       - unlabeled
 
-permissions:
-  pull-requests: read
-
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/lint-pr-title-preview-outputErrorMessage.yml
+++ b/.github/workflows/lint-pr-title-preview-outputErrorMessage.yml
@@ -6,7 +6,6 @@ on:
       - edited
       - synchronize
 
-
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-pr-title-preview-outputErrorMessage.yml
+++ b/.github/workflows/lint-pr-title-preview-outputErrorMessage.yml
@@ -6,12 +6,12 @@ on:
       - edited
       - synchronize
 
-permissions:
-  pull-requests: write
 
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/lint-pr-title-preview-validateSingleCommit.yml
+++ b/.github/workflows/lint-pr-title-preview-validateSingleCommit.yml
@@ -6,12 +6,11 @@ on:
       - edited
       - synchronize
 
-permissions:
-  pull-requests: read
-
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/lint-pr-title-preview.yml
+++ b/.github/workflows/lint-pr-title-preview.yml
@@ -6,12 +6,11 @@ on:
       - edited
       - synchronize
 
-permissions:
-  pull-requests: read
-
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -6,12 +6,11 @@ on:
       - edited
       - synchronize
 
-permissions:
-  pull-requests: read
-
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  deployments: write
-  issues: write
-  pull-requests: write
-
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      deployments: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,11 @@ on:
       - reopened
       - synchronize
 
-permissions:
-  contents: read
-
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -22,13 +21,15 @@ jobs:
 
   dist:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
         with: 
           fetch-depth: 0
       - name: Check if `dist/` has been modified.
         run: |
-          set -eux
+          set -euxo pipefail
 
           if [ $(git diff origin/main --name-only -- 'dist/**' | wc -l) -gt 0 ]
           then

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -4,11 +4,10 @@ on:
   release:
     types: [published, edited]
 
-permissions:
-  deployments: write
-
 jobs:
   actions-tagger:
     runs-on: ubuntu-latest
+    permissions:
+      deployments: write
     steps:
       - uses: Actions-R-Us/actions-tagger@v2

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 See the [event triggers documentation](#event-triggers) below to learn more about what `pull_request_target` means.
@@ -139,7 +139,7 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           wip: true
 ```
@@ -199,7 +199,7 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v5
         id: lint_pr_title
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: marocchino/sticky-pull-request-comment@v2
         # When the previous steps fails, the workflow would stop. By adding this

--- a/README.md
+++ b/README.md
@@ -31,17 +31,18 @@ on:
       - synchronize
       - reopened
 
-permissions:
-  pull-requests: read
-
 jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
+      - uses: actions/checkout@v4.2.2
       - uses: amannn/action-semantic-pull-request@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 ```
 
 See the [event triggers documentation](#event-triggers) below to learn more about what `pull_request_target` means.
@@ -135,10 +136,14 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
+      - uses: actions/checkout@v4.2.2
       - uses: amannn/action-semantic-pull-request@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           wip: true
 ```
@@ -192,11 +197,15 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
+      - uses: actions/checkout@v4.2.2
       - uses: amannn/action-semantic-pull-request@v5
         id: lint_pr_title
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - uses: marocchino/sticky-pull-request-comment@v2
         # When the previous steps fails, the workflow would stop. By adding this

--- a/README.md
+++ b/README.md
@@ -36,10 +36,8 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4.2.2
       - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -137,10 +135,8 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4.2.2
       - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -198,10 +194,8 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4.2.2
       - uses: amannn/action-semantic-pull-request@v5
         id: lint_pr_title
         env:

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ module.exports = async function run() {
               });
             } catch (error) {
               throw new Error(
-                `Pull request has only one commit and it's not semantic; this may lead to a non-semantic commit in the base branch (see https://github.com/community/community/discussions/16271). Amend the commit message to match the pull request title, or add another commit.`
+                `Pull request has only one commit and it's not semantic; this may lead to a non-semantic commit in the base branch (see https://github.com/community/community/discussions/16271 ). Amend the commit message to match the pull request title, or add another commit.`
               );
             }
 


### PR DESCRIPTION
# Description

Updated the GitHub Actions workflows to use permissions scope at the job-level (dedicated) instead of workflow level (shared) in case anyone copy-paste and adds some more jobs to the flow.
Updated the url provided in case of a non-compliant commit message, to have it resolved properly.

## Type of change

- [x] Bug fix
- [x] Security

## Changes required

- [x] Source code
- [x] CI/CD
- [x] GitHub Actions

## How Has This Been Tested?

- [x] Permissions block, `-o pipefail` flag, urlfix:
https://github.com/zMynxx/action-semantic-pull-request/pull/3

- [x] Invalid url fix:
before (invalid link):
https://github.com/zMynxx/action-semantic-pull-request/actions/runs/14055509974/job/39354003059#step:6:9
after (valid):
https://github.com/zMynxx/action-semantic-pull-request/actions/runs/14055844489/job/39355025376#step:6:9
<img width="1131" alt="Screenshot 2025-03-25 at 11 00 29" src="https://github.com/user-attachments/assets/eee7b244-65a8-4718-94c9-6eb152cd2d20" />