### PR TITLE
build: move Vitest to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "@actions/github": "^6.0.1",
     "conventional-changelog-conventionalcommits": "9.1.0",
     "conventional-commit-types": "^3.0.0",
-    "conventional-commits-parser": "^6.2.0",
-    "vitest": "^3.2.4"
+    "conventional-commits-parser": "^6.2.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.6",
@@ -46,7 +45,8 @@
     "prettier": "^3.6.2",
     "rollup": "^4.46.2",
     "semantic-release": "^24.2.7",
-    "semantic-release-major-tag": "0.3.2"
+    "semantic-release-major-tag": "0.3.2",
+    "vitest": "^3.2.4"
   },
   "engines": {
     "node": "^24.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       conventional-commits-parser:
         specifier: ^6.2.0
         version: 6.2.0
-      vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.2.1)(jiti@1.21.7)(yaml@2.8.1)
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^28.0.6
@@ -72,6 +69,9 @@ importers:
       semantic-release-major-tag:
         specifier: 0.3.2
         version: 0.3.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.2.1)(jiti@1.21.7)(yaml@2.8.1)
 
 packages:
 


### PR DESCRIPTION
<!--

Thank you very much for contributing to this project!

Please make sure to have a look at the [contributors guide](https://github.com/amannn/action-semantic-pull-request/blob/master/CONTRIBUTORS.md) so you can test your changes.

For any non-trivial changes, please include a link to a workflow where you've tested the current state of this pull request (see contributors guide).

-->

Looks like after #287 this got inadvertently put in `dependencies` rather than `devDependencies`
