### PR TITLE
fix: remove trailing whitespace from "unknown release type" error message

### DIFF
--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -75,7 +75,7 @@ export default async function validatePrTitle(
     raiseError(
       `Unknown release type "${
         result.type
-      }" found in pull request title "${prTitle}". \n\n${printAvailableTypes()}`
+      }" found in pull request title "${prTitle}".\n\n${printAvailableTypes()}`
     );
   }
 


### PR DESCRIPTION
Not the end of the world but still good to avoid :)