### PR TITLE
feat: support providing regexps for types

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,12 @@ feat(ui): Add `Button` component
 ```yml
         with:
           # Configure which types are allowed (newline-delimited).
+          # These are regex patterns auto-wrapped in `^ $`.
           # Default: https://github.com/commitizen/conventional-commit-types
           types: |
             fix
             feat
+            JIRA-\d+
           # Configure which scopes are allowed (newline-delimited).
           # These are regex patterns auto-wrapped in `^ $`.
           scopes: |

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ branding:
   color: 'green'
 inputs:
   types:
-    description: "Provide custom types (newline delimited) if you don't want the default ones from https://www.conventionalcommits.org."
+    description: "Provide custom types (newline delimited) if you don't want the default ones from https://www.conventionalcommits.org. These are regex patterns auto-wrapped in `^ $`."
     required: false
   scopes:
     description: 'Configure which scopes are allowed (newline delimited). These are regex patterns auto-wrapped in `^ $`.'

--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -71,7 +71,7 @@ export default async function validatePrTitle(
     raiseError(`No subject found in pull request title "${prTitle}".`);
   }
 
-  if (!types.includes(result.type)) {
+  if (!types.some((type) => new RegExp(`^${type}$`).test(result.type))) {
     raiseError(
       `Unknown release type "${
         result.type


### PR DESCRIPTION
<!--

Thank you very much for contributing to this project!

Please make sure to have a look at the [contributors guide](https://github.com/amannn/action-semantic-pull-request/blob/master/CONTRIBUTORS.md) so you can test your changes.

For any non-trivial changes, please include a link to a workflow where you've tested the current state of this pull request (see contributors guide).

-->

Similar to #226, this adds support for providing regexs for types which makes it possible to e.g. have Jira keys as a type.

This was about as straightforward as I expected though it turns out the conventional commit header pattern does not allow `-` characters meaning that also needs to be changed for Jira keys - it would be great if that was handled by the action either by just changing the default pattern entirely or by changing it when a custom type (or maybe even a "probably a regexp" type?) is detected, but either way that's out of scope for this particular change (let me know if you'd be open to it though).

Also something else this would be useful with is the ability to add additional types, rather than having the default list overridden - I'm happy to create a follow up issue and PR if that sounds useful.

Resolves #220

E2E tests:
  - https://github.com/G-Rath/action-semantic-pull-request/actions/runs/17050897437/job/48338016332?pr=1 (run on 6dc50d5ffd7779d1ce5daecf7a38ce33e6c7ea93)
  - https://github.com/G-Rath/action-semantic-pull-request/actions/runs/17050930498/job/48338123470?pr=1 (run on 6630606f80ff153109da9b750405839a2dfcb2c4, before updating title)
  - https://github.com/G-Rath/action-semantic-pull-request/actions/runs/17050959361/job/48338219475?pr=1 (run on 6630606f80ff153109da9b750405839a2dfcb2c4, after updating title)
  - https://github.com/G-Rath/action-semantic-pull-request/actions/runs/17051037594/job/48338495102?pr=1 (run on bb03ee007c0aada823e2b10ede5e060be4291c37, before changing title back)
  - https://github.com/G-Rath/action-semantic-pull-request/actions/runs/17051051107/job/48338541631?pr=1 (run on bb03ee007c0aada823e2b10ede5e060be4291c37, after changing title back)