### PR TITLE
docs: link to GitHub Actions docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,14 @@ name: 'Lint PR'
 on:
   pull_request_target:
     types:
+      # Defaults
+      # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target
       - opened
-      - edited
       - reopened
+      - synchronize
+      # Tracks editing PR title or description, or base branch changes
+      # https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#pull_request
+      - edited
 
 jobs:
   main:


### PR DESCRIPTION
I noticed that for rebasing the Action was not running, and I am fixing it locally for me.
Matching the defaults from GitHub action should fix that issue, and I believe that this
should be the default suggestion as well.

Also added links for anyone that may want to learn more.