### PR TITLE
docs(README): fix complete example

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,6 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-slim
-    permissions:
-      pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         id: lint_pr_title


### PR DESCRIPTION
# Motivation

I tested the complete example and it failed, because of read permission on PR. 
`marocchino/sticky-pull-request-comment` requires write permission ([source](https://github.com/marocchino/sticky-pull-request-comment?tab=readme-ov-file#error-resource-not-accessible-by-integration))
